### PR TITLE
feat(modding): Added missing functionality for StarbaseCaptured condition.

### DIFF
--- a/Starship/.vsconfig
+++ b/Starship/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [ 
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+} 

--- a/Starship/Assets/Scripts/Domain/Quests/Factory/RequirementsBuilder.cs
+++ b/Starship/Assets/Scripts/Domain/Quests/Factory/RequirementsBuilder.cs
@@ -89,7 +89,7 @@ namespace Domain.Quests
 
         public IRequirements Create(Requirement_StarbaseCaptured content)
         {
-            throw new System.NotImplementedException();
+            return new StarbaseCapturedRequirement( _motherShip );
         }
 
         public IRequirements Create(Requirement_Faction content)

--- a/Starship/Assets/Scripts/Domain/Quests/Requirements/StarbaseCapturedRequirement.cs
+++ b/Starship/Assets/Scripts/Domain/Quests/Requirements/StarbaseCapturedRequirement.cs
@@ -1,0 +1,33 @@
+﻿using GameServices.Player;
+using Services.Localization;
+
+namespace Domain.Quests
+{
+    public class StarbaseCapturedRequirement : IRequirements
+    {
+        public StarbaseCapturedRequirement (  MotherShip motherShip )
+        {
+            _motherShip = motherShip;
+        }
+
+        public bool IsMet
+        {
+            get
+            {
+                return _motherShip.CurrentStar.Region.IsCaptured && _motherShip.CurrentStar.Region.Faction.Id.Value != 0;
+            }
+        }
+
+        public int BeaconPosition => -1;
+
+        public bool CanStart ( int starId, int seed ) { return IsMet; }
+
+        public string GetDescription ( ILocalization localization )
+        {
+            return "$StarbaseMustBeCaptured";
+        }
+
+        private readonly MotherShip _motherShip;
+    }
+}
+

--- a/Starship/Assets/Scripts/Domain/Quests/Requirements/StarbaseCapturedRequirement.cs.meta
+++ b/Starship/Assets/Scripts/Domain/Quests/Requirements/StarbaseCapturedRequirement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6a2975d25cf19940a0cf9022628aca7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
StarbaseCaptured condition works on star nodes that belong to a faction excluding Free stars. The faction base has to be captured for the condition to work.