### PR TITLE
fix(gameplay): fixed enemies spawning too soon after calling enemies

### DIFF
--- a/Starship/Assets/Scripts/Combat/Manager/CombatManager.cs
+++ b/Starship/Assets/Scripts/Combat/Manager/CombatManager.cs
@@ -205,6 +205,7 @@ namespace Combat.Manager
         {
             if (!CanCallNextEnemy())
                 return;
+            _nextShipCooldown = 0;
 
             var shipInfo = _combatModel.EnemyFleet.Ships.FirstOrDefault(item => item.Status == ShipStatus.Ready);
             if (shipInfo == null)


### PR DESCRIPTION
If there are no enemy ships, _nextShipCooldown increments. If you call an enemy ship during this time period, then _nextShipCooldown is nonzero for the next time there are no enemy ships. This means that the next ship will spawn sooner than intended.