### PR TITLE
fix(misc): fixes exception in localization manager with null strings

### DIFF
--- a/Starship/Assets/Scripts/Services/Localization/LocalizationManager.cs
+++ b/Starship/Assets/Scripts/Services/Localization/LocalizationManager.cs
@@ -275,7 +275,10 @@ namespace Services.Localization
 
         private void ApplyInjections(ref string text)
         {
-	        if (_sessionData == null)
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            if (_sessionData == null)
 	        {
 		        text = FormatterRegex.Replace(text, "!!!Session is not initialized!!!");
 		        return;


### PR DESCRIPTION
Before a73b6461c5b6222c8930ee114657aceaa1c349dc null strings did not throw an exception. For example, getting minerals in Exploration as the last reward should exit the scene after 5 seconds; however, the exception prevents that from happening.