### PR TITLE
fix(gameplay): fixes immediate exception in exploration

### DIFF
--- a/Starship/Assets/Scripts/Gui/Combat/BeaconRadar.cs
+++ b/Starship/Assets/Scripts/Gui/Combat/BeaconRadar.cs
@@ -19,7 +19,6 @@ namespace Gui.Combat
             _unit = unit;
 
             Initialize();
-            Update();
             gameObject.SetActive(true);
         }
 


### PR DESCRIPTION
After f9c1d59d15de4c2da9c8d2e7a6e6147c19ceb6c2 the extra Update() call happens before Start() which causes a NullReferenceException.