### PR TITLE
fix(misc): fixed shops not decrementing renewable items after purchase

### DIFF
--- a/Starship/Assets/Scripts/Domain/Economy/Products/Products.cs
+++ b/Starship/Assets/Scripts/Domain/Economy/Products/Products.cs
@@ -224,6 +224,8 @@ namespace Economy.Products
             if (!price.TryWithdraw(_playerResources))
             	throw new System.InvalidOperationException();
 
+            _purchasedCount += amount;
+
             _session.Shop.SetPurchase(_marketId, Type.Id, _purchasedCount);
 
             Type.Consume(amount);


### PR DESCRIPTION
The original logic incremented _purchasedCount when price.Currency was not Current.Money: https://github.com/PavelZinchenko/event_horizon/blob/0b259a3c0860e152ccb6f1d0e48903f3dc748483/Starship/Assets/Scripts/Domain/Economy/Products/Products.cs#L224-L232 So _purchasedCount should always be incremented since Currency.Money was removed in da9ee0eff1d5cbaf70aa59e7054cd9228d350f99.